### PR TITLE
Locking to site-inspector 1.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:2.3-alpine
 # https://github.com/gliderlabs/docker-alpine/issues/53#issuecomment-125671731
 RUN apk add --update build-base libxml2-dev libxslt-dev
 RUN gem install nokogiri -- --use-system-libraries
-RUN gem install site-inspector --no-ri --no-rdoc
+RUN gem install site-inspector -v 1.0.2 --no-ri --no-rdoc
 
 ENTRYPOINT ["site-inspector"]
 CMD ["--help"]


### PR DESCRIPTION
For the purposes of domain-scan, we currently depend on 1.0.2.
